### PR TITLE
Adding script to reduce spAll file

### DIFF
--- a/bin/picca_reduce_spall.py
+++ b/bin/picca_reduce_spall.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from astropy.table import Table
+import argparse
+import numpy as np
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--spall',
+                    type=str,
+                    required=True,
+                    help='Path to spAll file')
+parser.add_argument('--qso-catalog',
+                    type=str,
+                    required=True,
+                    help='Path to file containing THING_ID (e.g. DR16Q.fits)')
+parser.add_argument('--output',
+                    type=str,
+                    required=True,
+                    help='Path to output reduced spAll file')
+
+args = parser.parse_args()
+
+print('Reading spAll file from')
+print(args.spall)
+spall = Table.read(args.spall)
+print(f'{len(spall)} entries found in spAll file')
+print('Reading QSO catalog from')
+print(args.qso_catalog)
+qso_catalog = Table.read(args.qso_catalog)
+print(f'{len(qso_catalog)} entries found in QSO catalog')
+
+w = np.in1d(spall['THING_ID'], qso_catalog['THING_ID'])
+spall_qso = spall[w]
+#-- Columns required for picca_deltas.py for spec, spplate formats and usage of multiple observations
+spall_qso.keep_columns(
+    ['THING_ID', 'PLATE', 'MJD', 'FIBERID', 'PLATEQUALITY', 'ZWARNING'])
+spall_qso.write(args.output, overwrite=True)


### PR DESCRIPTION
Adding this script to make a smaller version of spAll file which contains only the information needed when running picca_deltas with spec or spplate input formats and using multiple observations. 
It reduces the time spent reading the same information from few tens of minutes to less than a second for DR16.

Here is an example of how you would call it @ NERSC: 

```
picca_reduce_spall.py --spall /global/projecta/projectdirs/sdss/staging/ebosswork/eboss/spectro/redux/v5_13_0/spAll-v5_13_0.fits --qso-catalog $REDO_DR16/Catalogs/DR16Q.fits --output $REDO_DR16/Catalogs/spAll-v5_13_0-DR16Q_test.fits
```

