### PR TITLE
Patch for enabling picca_plot_Pk1d

### DIFF
--- a/bin/picca_plot_pk1d.py
+++ b/bin/picca_plot_pk1d.py
@@ -99,8 +99,8 @@ def main():
                     (pk.k[index2] - k_min) / (k_max - k_min) * num_k_bins)
                 if index_k >= num_k_bins or index_k < 0:
                     continue
-                sum_pk[index_z, index_k] += pk.Pk[index2] * pk.k[index2] / np.pi
-                sum_pk_square[index_z, index_k] += (pk.Pk[index2] *
+                sum_pk[index_z, index_k] += pk.pk[index2] * pk.k[index2] / np.pi
+                sum_pk_square[index_z, index_k] += (pk.pk[index2] *
                                                     pk.k[index2] / np.pi)**2
                 counts[index_z, index_k] += 1.0
 

--- a/py/picca/pk1d.py
+++ b/py/picca/pk1d.py
@@ -456,7 +456,7 @@ class Pk1D:
         pk = data['Pk'][:]
         pk_raw = data['Pk_raw'][:]
         pk_noise = data['Pk_noise'][:]
-        correction_reso = data['correction_reso'][:]
+        correction_reso = data['cor_reso'][:]
         pk_diff = data['Pk_diff'][:]
 
         return cls(ra, dec, z_qso, mean_z, plate, mjd, fiberid, mean_snr,


### PR DESCRIPTION
The following changes are needed to read the pk1d outputs the way picca_plot_Pk1d (or any existing plotting tools that were based on it) do.